### PR TITLE
Optimize InputScalingHelper & add gas-snapshot

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,4 @@
+InputScalingTest:testSwapSimpleMode_Decrease() (gas: 2952912)
+InputScalingTest:testSwapSimpleMode_Increase() (gas: 2935382)
+InputScalingTest:testSwap_DecreaseETH() (gas: 2462574)
+InputScalingTest:testSwap_IncreaseETH() (gas: 2462550)


### PR DESCRIPTION
![image](https://github.com/KyberNetwork/ks-helper-sc/assets/20136490/89c6d703-78ee-4ffd-ae4a-8d2ec4ca2798)

Comparison of Pre-Optimization (left) and Post-Optimization (right):

Optimizations Applied:

- Direct use of byte slice in abi.decode for calldata
- Caching of array length to memory variable
- Use of unchecked arithmetic
- Removal of redundant memory assignment in `_scaledPositiveSlippageFeeData`. A `bytes memory` assignment does not clone, but rather creates a new reference to the same memory chunk. Therefore, it can be safely eliminated.