### PR TITLE
Fix unnecessary external of writeSwapExecutorDescription library & fix view to pure

### DIFF
--- a/src/l2-contracts/CalldataWriter.sol
+++ b/src/l2-contracts/CalldataWriter.sol
@@ -24,7 +24,7 @@ library CalldataWriter {
    ************************ AggregationExecutor ************************
    */
   function writeSwapExecutorDescription(IExecutorHelperL2.SwapExecutorDescription memory desc)
-    external
+    internal
     pure
     returns (bytes memory shortData)
   {

--- a/src/l2-contracts/InputScalingHelperL2.sol
+++ b/src/l2-contracts/InputScalingHelperL2.sol
@@ -76,7 +76,7 @@ contract InputScalingHelperL2 {
   function getScaledInputData(
     bytes calldata inputData,
     uint256 newAmount
-  ) external view returns (bytes memory) {
+  ) external pure returns (bytes memory) {
     bytes4 selector = bytes4(inputData[:4]);
     bytes calldata dataToDecode = inputData[4:];
 
@@ -337,7 +337,7 @@ contract InputScalingHelperL2 {
     return swap;
   }
 
-  function _flagsChecked(uint256 number, uint256 flag) internal view returns (bool) {
+  function _flagsChecked(uint256 number, uint256 flag) internal pure returns (bool) {
     return number & flag != 0;
   }
 }


### PR DESCRIPTION
This PR contains two fixes, as stated in the title. The unnecessary use of `external` in `writeSwapExecutorDescription` requires the CalldataWriter library to be deployed as an external library, leading to unnecessary complications and higher gas usage.